### PR TITLE
Add section 'Editor and IDE Integrations'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Tools](#tools)
 - [Blog posts and opinions](#blog-posts-and-opinions)
 - [Playbooks and Roles](#playbooks-and-roles)
+- [Editor and IDE Integrations](#editor-and-ide-integrations)
 
 ## Official resources
 
@@ -113,3 +114,11 @@
 - [DebOps](https://docs.debops.org/en/master/) - A extensive collection of Debian based Ansible Playbooks.
 - [ansible-ssm](https://github.com/HQarroum/ansible-ssm) - An ansible role to provision physical and virtual hosts with the AWS SSM agent.
 - [BlueBanquise](https://github.com/bluebanquise/bluebanquise) - An ansible coherent roles collection to deploy clusters.
+
+## Editor and IDE Integrations
+
+> Awesome Integrations into Text Editors and IDE's to make development with/for Ansible easier.
+
+- [Ansible Language Server](https://github.com/ansible/ansible-language-server) - Language Server that adds support for Ansible, to compatible Editors.
+- [Emacs - Ansible client for Language Server Protocol](https://emacs-lsp.github.io/lsp-mode/page/lsp-ansible/) - Emacs support for Ansible Language Server Protocol.
+- [VS Code - official Ansible Extension](https://marketplace.visualstudio.com/items?itemName=redhat.ansible) - Adds language support for Ansible to Visual Studio Code and OpenVSX compatible editors by leveraging ansible-language-server.


### PR DESCRIPTION
This adds a Section on Editors and IDE Integrations for Ansible, it's based on personal experience, and inspired by this Page from the official Documentation: [other_tools_and_programs](https://github.com/ansible/ansible/blob/2797dc644aa8c809444ccac64cad63e0d9a3f9fe/docs/docsite/rst/community/other_tools_and_programs.rst)

The official Documentation does recommend some general Purpose Extensions and specific Editors, but those are either not Ansible specific enough, or outdated, those I have omitted.

I personally use VS Code, and the official Ansible Language Support Extension, if anyone else wants to add to the Section, for their favorite IDE or Editor, please feel free to do so!

As more Extensions for multiple different Editors might be added, we might want to split the Section up into Editor/IDE Specific sections, for now, I find it to be enough to start the Link Title with the Editor for which the Integration is, to both, make it easy to visually grep for a specific Editor, and to sort/group multiple Items for an Editor together.