### PR TITLE
Merge `other_tools_and_programs`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@
 - [ansible-builder](https://ansible-builder.readthedocs.io/en/latest/) - Using Ansible content that depends on non-default dependencies can be tricky. Packages must be installed on each node, play nicely with other software installed on the host system, and be kept in sync.
 - [ansible-toolset](https://github.com/ansible-community/toolset) - Ansible Toolset combines all ansible development tools in a single container: ansible, ansible-lint and molecule.
 - [kics](https://github.com/Checkmarx/kics) - SAST Tool that scans your ansible infrastructure as code playbooks for security vulnverables, compliance issues and misconfigurations.
-
+- [php-ansible Library](https://github.com/maschmann/php-ansible) - OOP-Wrapper for Ansible, making Ansible available in PHP.
+- [TD4A](https://github.com/cidrblock/td4a) - Design aid for building and testing jinja2 templates, combines data in yaml format with a jinja2 template and render the output.
+- [Ansible Playbook Grapher](https://github.com/haidaraM/ansible-playbook-grapher) - Command line tool to create a graph representing your Ansible playbook plays, tasks and roles.
 
 ## Blog posts and opinions
 


### PR DESCRIPTION
This Merges all awesome tools (Beside Editor Stuff) from the follwoing document:
[other_tools_and_programs](https://github.com/ansible/ansible/blob/2797dc644aa8c809444ccac64cad63e0d9a3f9fe/docs/docsite/rst/community/other_tools_and_programs.rst)

Lots of Things where omitted, some where already on the list, and three Items where ultimately added to the list!

- added [php-ansible](https://github.com/maschmann/php-ansible) - I personally dont work with php, but I see how this would be awesome for anyone wanting to interface with Ansible via PHP.
- added [TD4A](https://github.com/cidrblock/td4a) - neat little Tool, for working with Jinja2 Templates.
- added [Ansible Playbook Grapher](https://github.com/haidaraM/ansible-playbook-grapher) - Command line tool to create a graph representing your Ansible playbook plays, tasks and roles.
- omitted [opstools-ansible](https://github.com/centos-opstools/opstools-ansible) - Not Maintained anymore, to Old.
- omitted [nanvault](https://github.com/marcobellaccini/nanvault) - I think this tool does not add enough value to be deemed awesome, all it's functionality can be realized with ansible-vault.
- omitted [ansigenome](https://github.com/dr1s/ansigenome) - Looks cool, is no longer maintained though.
- omitted [ansible-shell](https://github.com/dominis/ansible-shell) - As of Ansible 2.1 merged into ansible itself, no longer maintained!
- omitted [ansible-silo](https://github.com/groupon/ansible-silo) - Essentially Ansible in a container Image, cool but Not actively maintained!
- omitted [ansible-inventory-grapher](https://github.com/willthames/ansible-inventory-grapher) - Neat Idea, sadly outdated and not actively maintained.
- omitted [Ansible Language Server](https://www.npmjs.com/package/@ansible/ansible-language-server) - Omitted, because it will be added in the pr #59.
- ommited [Ansible Review](https://github.com/willthames/ansible-review) - Sadly not actively maintained.