### PR TITLE
Add non-english subsection to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@
 - [Testing Ansible Roles Against Windows with Test-Kitchen](https://hodgkins.io/testing-ansible-roles-windows-test-kitchen) - Using Test-Kitchen with Ansible to apply playbooks to Windows machines and test them with [Pester](https://github.com/pester/Pester/).
 - [Ansible Best Practices by AndiDog](https://andidog.de/blog/2017-04-24-ansible-best-practices) - Practices covering many aspects of an Ansible setup, including hints to support different environments (testing, staging, production).
 
-### Other languages than English
+### German
 
-- [Ansible auf My-IT-Brain (German)](https://www.my-it-brain.de/wordpress/category/ansible/) - Articles about different topics regarding Ansbile, e.g. modules, roles, use cases, etc.
+- [Ansible auf My-IT-Brain](https://www.my-it-brain.de/wordpress/category/ansible/) - Articles about different topics regarding Ansbile, e.g. modules, roles, use cases, etc.
 
 ## Playbooks and Roles
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@
 - [Testing Ansible Roles Against Windows with Test-Kitchen](https://hodgkins.io/testing-ansible-roles-windows-test-kitchen) - Using Test-Kitchen with Ansible to apply playbooks to Windows machines and test them with [Pester](https://github.com/pester/Pester/).
 - [Ansible Best Practices by AndiDog](https://andidog.de/blog/2017-04-24-ansible-best-practices) - Practices covering many aspects of an Ansible setup, including hints to support different environments (testing, staging, production).
 
+### Other languages than English
+
+- [Ansible auf My-IT-Brain (German)](https://www.my-it-brain.de/wordpress/category/ansible/) - Articles about different topics regarding Ansbile, e.g. modules, roles, use cases, etc.
+
 ## Playbooks and Roles
 
 > Awesome production ready Playbooks and Roles to get you up and running.


### PR DESCRIPTION
As discussed during today's Ansible Contribution Summit I'd like to propose a subsection for non-english content.  This PR shows a new subsection in 'Blog posts and opinions'.

There is just the beginning of a new list. The language of the content is mentioned in the entry. In case there will be multiple different languages in the future the list could be sorted or new subsections for different languages could be introduced.

This example could be used for other sections like videos, tools, etc. too.