### PR TITLE
Add Monkeyble in tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ You can find the full list and how to connect in the official documentation [doc
 - [ansible-doc-extractor](https://github.com/xlab-steampunk/ansible-doc-extractor) - A tool that extracts documentation from Ansible modules in the HTML form.
 - [Ansible Semaphore](https://github.com/ansible-semaphore/semaphore) - Ansible Semaphore is a modern UI for Ansible.
 - [Steampunk Spotter](https://steampunk.si/spotter/) - Provides an Assisted Automation Writing tool that analyzes and offers recommendations for your Ansible Playbooks.
+- [Monkeyble](https://hewlettpackard.github.io/monkeyble/) - A callback plugin that allow to execute end-to-end tests on playbooks with a Pythonic testing and CI/CD approach to detect regressions.
 
 ## Blog posts and opinions
 


### PR DESCRIPTION
Add HewlettPackard/monkeyble in tools list.

"This is a callback plugin for Ansible that allow to execute end-to-end tests on Ansible playbooks with a Pythonic testing approach.
Monkeyble is designed to be executed by a CI/CD in order to detect regressions when updating an Ansible code base."

What problematic is Monkeyble trying to address? See https://github.com/HewlettPackard/monkeyble#do-i-need-monkeyble