### PR TITLE
Add search link for ansible related repo of redhat-cop

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ You can find the full list and how to connect in the official documentation [doc
 - [DebOps](https://docs.debops.org/en/master/) - A extensive collection of Debian based Ansible Playbooks.
 - [ansible-ssm](https://github.com/HQarroum/ansible-ssm) - An ansible role to provision physical and virtual hosts with the AWS SSM agent.
 - [BlueBanquise](https://github.com/bluebanquise/bluebanquise) - An ansible coherent roles collection to deploy clusters.
+- [redhat-cop](https://github.com/search?q=topic%3Aansible+org%3Aredhat-cop&type=Repositories&s=updated&o=desc) - Reposirories with ansible topic of the Red Hat Communities of Practice project.
 
 ## Editor and IDE Integrations
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ You can find the full list and how to connect in the official documentation [doc
 - [DebOps](https://docs.debops.org/en/master/) - A extensive collection of Debian based Ansible Playbooks.
 - [ansible-ssm](https://github.com/HQarroum/ansible-ssm) - An ansible role to provision physical and virtual hosts with the AWS SSM agent.
 - [BlueBanquise](https://github.com/bluebanquise/bluebanquise) - An ansible coherent roles collection to deploy clusters.
-- [redhat-cop](https://github.com/search?q=topic%3Aansible+org%3Aredhat-cop&type=Repositories&s=updated&o=desc) - Reposirories with ansible topic of the Red Hat Communities of Practice project.
+- [redhat-cop](https://github.com/search?q=topic%3Aansible+org%3Aredhat-cop&type=Repositories&s=updated&o=desc) - Repositories with ansible topic of the Red Hat Communities of Practice project.
 
 ## Editor and IDE Integrations
 


### PR DESCRIPTION
Add [redhat-cop](https://github.com/redhat-cop) in 'Playbooks, Roles and Collections' section.

This organization provides repositories with a set of generic collections, roles and reusable playbooks for deploying automation platform (Controller/Tower, Hub, Execution Environment, network, etc.).