### PR TITLE
docs(tutorial): add ansible for devops example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ You can find the full list and how to connect in the official documentation [doc
 - [Ansible Tutorial by BlueBanquise team](http://bluebanquise.com/documentation/releases/1.5.0/training_ansible.html) - Basic Ansible tutorial.
 - [Ansible Tutorial for Beginners: Playbook & Examples](https://spacelift.io/blog/ansible-tutorial) - Introduction to Ansible for beginners.
 - [Ansible Tutorials for Beginners and Advanced](https://ansible.puzzle.ch/) - Workshop on multiple topics with different levels of difficulty.
+- [Ansible For DevOps](https://github.com/geerlingguy/ansible-for-devops) - This repository contains Ansible examples developed to support different sections of [Ansible for DevOps](https://www.ansiblefordevops.com), a book on Ansible by Jeff Geerling.
 
 ## Books
 


### PR DESCRIPTION
Add Ansible for DevOps example in tutorials list.

This is a collection of labs in the "[Ansible for DevOps](https://www.ansiblefordevops.com)" book.

I think this is very important to add when reading the book.