### PR TITLE
ansible-hpc - Modular Ansible playbooks for automated HPC cluster deployment and monitoring on Rocky Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ For more information about communication, see the [Ansible communication guide](
 - [antsichaut](https://github.com/ansible-community/antsichaut) - Automate the filling of a changelog.yaml used by antsibull-changelog.
 - [ansibledb](https://github.com/nbentoumi/ansibledb) - Flask API Web server that uses MongoDB as database to store Ansible reports and facts; this tool can be used to query hosts and facters managed Ansible as well search Ansible logs.
 - [Ansible Template Playground](https://tech-playground.com/playgrounds/ansible-template/) - Online playground for running, testing and sharing Ansible templates.
+- [ansible-hpc](https://github.com/psantana5/ansible-hpc) - Modular Ansible playbooks for automated HPC cluster deployment and monitoring on Rocky Linux.
 
 ## Blog posts and opinions
 


### PR DESCRIPTION
Ansible-hpc provides modular, production-ready Ansible playbooks for deploying and monitoring HPC clusters on Rocky Linux. It integrates SLURM, NFS, LDAP, Prometheus, Grafana, Spack and much more, with a focus on energy efficiency and best practices. The project is actively maintained and designed for extensibility in research and enterprise environments.